### PR TITLE
Specify python 3.4 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 3.4
 env:
   - TOXENV=py34
 install: pip install tox coveralls


### PR DESCRIPTION
If you don't specify python 3.4, your non-tox environment is 2.7 currently. This means when you run your tests, everything is fine, but in after_success when you run coveralls, it's in 2.7. When coveralls parses your source code as 2.7, it doesn't understand any of the new syntax and considers the file as not-python.