### PR TITLE
Changed the connect/disconnect coroutines to use a task instead of yield from

### DIFF
--- a/bottom/connection.py
+++ b/bottom/connection.py
@@ -29,8 +29,8 @@ class Connection(object):
         self.writer = None
         self.reader = None
         self._connected = False
-        yield from self.events.trigger(
-            "CLIENT_DISCONNECT", host=self.host, port=self.port)
+        asyncio.Task(self.events.trigger(
+            "CLIENT_DISCONNECT", host=self.host, port=self.port))
 
     @property
     def connected(self):

--- a/bottom/connection.py
+++ b/bottom/connection.py
@@ -18,8 +18,8 @@ class Connection(object):
         self.reader, self.writer = yield from asyncio.open_connection(
             self.host, self.port, ssl=self.ssl, loop=loop)
         self._connected = True
-        yield from self.events.trigger(
-            "CLIENT_CONNECT", host=self.host, port=self.port)
+        asyncio.Task(self.events.trigger(
+            "CLIENT_CONNECT", host=self.host, port=self.port))
 
     @asyncio.coroutine
     def disconnect(self):


### PR DESCRIPTION
Changed the connect/disconnect coroutines to use a task instead of yield from. This is necessary because any blocking coroutines in a triggered 'connect' event will prevent any further triggers from being called.

As a simple example of why this is necessary, the following example should be more than enough to prove the necessity:

    @bot.on('CLIENT_CONNECT')
    def connect():
        bot.send('NICK', nick=nick)
        bot.send('USER', user=nick, realname='Segmund')
        yield from asyncio.sleep(1000)