### PR TITLE
Fix intermittent missing client in Protocol

### DIFF
--- a/bottom/client.py
+++ b/bottom/client.py
@@ -42,11 +42,17 @@ class Client:
         self.protocol.write(packed_command)
 
     async def connect(self):
+        def protocol_factory():
+            return Protocol(client=self)
+
         transport, protocol = await self.loop.create_connection(
-            Protocol, host=self.host, port=self.port, ssl=self.ssl)
+            protocol_factory, host=self.host, port=self.port, ssl=self.ssl)
         if self.protocol:
             self.protocol.close()
         self.protocol = protocol
+        # TODO: Delete the following code line. It is currently kept in order
+        # to not break the current existing codebase. Removing it requires a
+        # heavy change in the test codebase.
         protocol.client = self
         self.trigger("client_connect")
 

--- a/bottom/protocol.py
+++ b/bottom/protocol.py
@@ -8,10 +8,11 @@ log = logging.getLogger('bottom')
 
 
 class Protocol(asyncio.Protocol):
-    client = None
-    closed = False
-    transport = None
-    buffer = b""
+    def __init__(self, client=None):
+        self.client = client
+        self.closed = False
+        self.transport = None
+        self.buffer = b""
 
     def connection_made(self, transport):
         self.transport = transport


### PR DESCRIPTION
First of all, thank you for this library! @mozilla-releng uses it for a project called [pulse-notify](https://github.com/mozilla-releng/pulse-notify). It allows us to send Firefox's build status via IRC.

We're experiencing an intermittent error (described more thoroughly in [bug 1339377](https://bugzilla.mozilla.org/show_bug.cgi?id=1339377)). Basically, `self.client` in [protocol](https://github.com/numberoverzero/bottom/blob/0bf923ad64d92b9f121e43b72107e15fd9e71523/bottom/protocol.py#L31) is sometime not defined yet. That's because the protocol already handles some requests, even before `protocol.client` is assigned at this line.

One easy way to trigger this bug, is to connect to irc.mozilla.org. The first message comes in blazing fast, which throws the error immediately.

I didn't manage to write an integration test that points out the bug. I see the bug being fixed manually, though. What slowed me down in writing the bug is the following: The fake server, already [passes itself to the protocol](https://github.com/numberoverzero/bottom/blob/e67d4d5ea98a8644f5fe5d70433d10bccd3284be/tests/integ/conftest.py#L109), just like this patch does. Hence, I'm not sure of to tackle the test. If you have any suggestion @numberoverzero, I'd be ready to implement. 

