### PR TITLE
Send raw messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-.PHONY: docs, clean, publish
+.PHONY: docs clean publish
 
 docs:
-	tox -e docs
 	cd docs && $(MAKE) html
 	firefox docs/_build/html/index.html
 

--- a/bottom/__init__.py
+++ b/bottom/__init__.py
@@ -1,4 +1,5 @@
-""" asyncio-based rfc2812-compliant IRC Client """
-from bottom.client import Client
-__all__ = ["Client"]
-__version__ = "2.0.1"
+"""asyncio-based rfc2812-compliant IRC Client"""
+from .client import Client, rfc2812_handler
+from .protocol import Protocol
+__all__ = ["Client", "Protocol", "rfc2812_handler"]
+__version__ = "2.1.0"

--- a/docs/user/api.rst
+++ b/docs/user/api.rst
@@ -211,17 +211,17 @@ You can schedule a non-blocking connect with the client's event loop:
 
 .. code-block:: python
 
-    await client.connect()
+    await client.disconnect()
 
 Immediately disconnect from the server.
 
 .. code-block:: python
 
     @bot.on('privmsg')
-    async def suicide_pill(nick, message, **kwargs):
-        if nick == "spy_handler" and message == "last stop":
+    async def disconnect_bot(nick, message, **kwargs):
+        if nick == "myNick" and message == "disconnect:hunter2":
             await bot.disconnect()
-            logger.log("cleaned up spy.")
+            logger.log("disconnected bot.")
 
 
 Like ``connect``, use the bot's event loop to schedule a disconnect:
@@ -239,3 +239,37 @@ Like ``connect``, use the bot's event loop to schedule a disconnect:
     client.send(command, **kwargs)
 
 Send a command to the server.  See `Commands <user/commands.html>`_.
+
+
+``Client.handle_raw``
+=====================
+
+.. versionadded:: 2.1.0
+
+.. code-block:: python
+
+    client.handle_raw(message)
+
+Manually inject a raw command.  The client's ``raw_handlers`` will process
+the message.  By default, every ``Client`` is configured with a ``rfc2812_handler``
+which unpacks a conforming rfc 2812 message into an event and calls ``client.trigger``.
+
+You can disable this functionality by removing the handler:
+
+.. code-block:: python
+
+    client = Client(host="localhost", port=443)
+    client.raw_handlers.clear()
+
+
+``Client.send_raw``
+===================
+
+.. versionadded:: 2.1.0
+
+.. code-block:: python
+
+    client.send_raw(message)
+
+Send a complete IRC line without the Client reconstructing or modifying the message.
+To easily send an rfc 2812 message, you should instead consider ``Client.send``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alabaster
+alabaster==0.7.10
 coverage
 flake8
 mypy

--- a/tests/integ/test_local.py
+++ b/tests/integ/test_local.py
@@ -14,6 +14,7 @@ def test_ping_pong(client, server, connect, flush):
     assert not server.received
 
     flush()
+    flush()
 
     # Both should have been received now
     assert client.triggers["PING"] == 1

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,12 +1,45 @@
 import asyncio
 import pytest
-from bottom.client import Client
+from bottom.client import Client, RawClient, process
 
 
 def test_default_event_loop():
     default_loop = asyncio.get_event_loop()
-    client = Client(host="host", port="port")
+    client = Client(host="host", port=3)
     assert client.loop is default_loop
+
+
+def test_default_raw_handlers(loop, flush):
+    raw_client = RawClient("host", 3, loop=loop)
+    client = Client("host", 3)
+    assert not raw_client.raw_handlers
+    assert len(client.raw_handlers) == 1
+
+    raw_client.handle_raw("message")
+    flush()
+
+
+def test_stop_processing(loop, flush):
+    calls = []
+
+    async def first(next_handler, message):
+        calls.append(("first", message))
+        await next_handler(message[::-1])
+
+    async def second(next_handler, message):
+        calls.append(("second", message))
+
+    async def not_called(next_handler, message):
+        calls.append(("not_called", message))
+        await next_handler(message)
+
+    task = process([first, second, not_called], "123")
+    loop.create_task(task)
+    flush()
+    assert calls == [
+        ("first", "123"),
+        ("second", "321")
+    ]
 
 
 def test_send_unknown_command(active_client, protocol):

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -46,16 +46,18 @@ def test_multipart_line(protocol, transport, active_client, flush):
     assert active_client.triggers["PRIVMSG"] == 1
 
 
-def test_multiline_chunk(protocol, transport, active_client):
+def test_multiline_chunk(protocol, transport, active_client, flush):
     """Multiple IRC lines in a single data_received block"""
     protocol.data_received(
         b":nick!user@host PRIVMSG #target :this is message\r\n" * 2)
+    flush()
     assert active_client.triggers["PRIVMSG"] == 2
 
 
-def test_invalid_line(protocol, transport, active_client):
+def test_invalid_line(protocol, transport, active_client, flush):
     """Well-formatted but invalid line"""
     protocol.data_received(b"blah unknown command\r\n")
+    flush()
     assert list(active_client.triggers.keys()) == ['CLIENT_CONNECT']
 
 


### PR DESCRIPTION
**2.1.0**: Client supports two new methods, roughly analogous to `send` and `trigger` respectively:

* `send_raw(message: str) -> None`
* `handle_raw(message: str) -> None`

Additionally, there is now a public attribute `raw_handlers` which is a list of asynchronous functions to invoke during `handle_raw`.  The first function is invoked with the original message and a reference to the next handler; it has full control to send a different message, or not call the next handler at all.

The simplest handler would be:

```
async def passthrough(next_handler, message):
    await next_handler(message)
```

The docs include more complex examples, such as transparently redirecting the message on privmsg, or base64 decoding and decrypting messages before passing them to the underlying rfc2812 handler.

By default, `Client` instances start with an rfc2812 handler.  Because `Client.raw_handlers` is just a list, it can be removed or cleared.  Handler order is significant.


**Other changes**:

* `Client._handlers` has been renamed to `Client._event_handlers` as there are now two levels of dispatch.  Because the attribute is not public, this is not a major version change.