### PR TITLE
return event name from RawClient.wait()

### DIFF
--- a/bottom/client.py
+++ b/bottom/client.py
@@ -102,8 +102,9 @@ class RawClient:
         async_event.set()
         async_event.clear()
 
-    async def wait(self, event: str) -> None:
+    async def wait(self, event: str) -> str:
         await self._events[event.upper()].wait()
+        return event
 
     def on(self, event: str, func: Optional[Callable] = None) -> Callable:
         """

--- a/examples/common.py
+++ b/examples/common.py
@@ -29,9 +29,15 @@ def waiter(client):
             loop=client.loop,
             return_when=return_when)
 
+        # Get the result(s) of the completed task(s).
+        ret = [future.result() for future in done]
+
         # Cancel any events that didn't come in.
         for future in pending:
             future.cancel()
+
+        # Return list of completed event names.
+        return ret
     return wait_for
 
 

--- a/examples/common.py
+++ b/examples/common.py
@@ -51,7 +51,19 @@ async def on_connect(**kwargs):
     client.send('user', user=NICK,
                 realname='https://github.com/numberoverzero/bottom')
 
-    await wait_for('rpl_endofmotd', 'err_nomotd')
+    # This waits for the 'rpl_endofmotd' and 'err_nomotd' commands,
+    # returning when one of them is triggered. 'events' is a list,
+    # but it will only contain one item in this case since only one
+    # of these commands will be sent by the server.
+    events = await wait_for('rpl_endofmotd', 'err_nomotd')
+    print('Connection made')
+
+    # The event names returned are the same as the ones given, so
+    # we can easily check for them in the result.
+    if 'rpl_endofmotd' in events:
+        print('MOTD returned')
+    elif 'err_nomotd' in events:
+        print('No MOTD returned')
 
     client.send('join', channel=CHANNEL)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -228,12 +228,14 @@ def test_wait_ordering(client, flush):
     flush()
     assert invoked == ["handler", "waiter"]
 
+
 def test_wait_return_value(client, flush):
     """ The value returned should be the same as the value given. """
     event_name = "test_wait_return_value"
     returned_name = ""
 
     async def waiter():
+        nonlocal returned_name
         returned_name = await client.wait(event_name)
 
     client.loop.create_task(waiter())

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -227,3 +227,17 @@ def test_wait_ordering(client, flush):
     client.trigger("some.trigger")
     flush()
     assert invoked == ["handler", "waiter"]
+
+def test_wait_return_value(client, flush):
+    """ The value returned should be the same as the value given. """
+    event_name = "test_wait_return_value"
+    returned_name = ""
+
+    async def waiter():
+        returned_name = await client.wait(event_name)
+
+    client.loop.create_task(waiter())
+    flush()
+    client.trigger(event_name)
+    flush()
+    assert returned_name is event_name


### PR DESCRIPTION
Not particularly useful on it's own, but very useful when using the `wait_for` function as implemented in `examples/common.py`.