### PR TITLE
Handling MODE returned by server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,3 +131,4 @@ Contributors
 * `Johan Lorenzo <https://github.com/JohanLorenzo>`_
 * `Dominik Miedziński <https://github.com/miedzinski>`_
 * `Yay295 <https://github.com/Yay295>`_
+* `Elijah Lazkani <https://github.com/elazkani>`_

--- a/bottom/__init__.py
+++ b/bottom/__init__.py
@@ -2,4 +2,4 @@
 from .client import Client, rfc2812_handler
 from .protocol import Protocol
 __all__ = ["Client", "Protocol", "rfc2812_handler"]
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/bottom/unpack.py
+++ b/bottom/unpack.py
@@ -302,11 +302,14 @@ def unpack_command(msg: str) -> Tuple[str, Dict[str, Any]]:
 
     elif command in ["MODE"]:
         nickmask(prefix, kwargs)
-        if len(params) > 2:
+        if "#" in params[0]:
             command = "CHANNELMODE"
             kwargs["channel"] = params[0]
             kwargs["modes"] = params[1]
-            kwargs["params"] = params[2]
+            if len(params) > 2:
+                kwargs["params"] = params[2:]
+            else:
+                kwargs["params"] = ""
         else:
             command = "USERMODE"
             kwargs["nick"] = params[0]
@@ -398,7 +401,7 @@ def parameters(command: str) -> List[str]:
         add_nickmask(params)
         params.append("nick")
         params.append("modes")
-        
+
     elif command in ["CHANNELMODE"]:
         add_nickmask(params)
         params.append("channel")

--- a/bottom/unpack.py
+++ b/bottom/unpack.py
@@ -300,6 +300,18 @@ def unpack_command(msg: str) -> Tuple[str, Dict[str, Any]]:
         else:
             kwargs["message"] = ""
 
+    elif command in ["MODE"]:
+        nickmask(prefix, kwargs)
+        if len(params) > 2:
+            command = "CHANNELMODE"
+            kwargs["channel"] = params[0]
+            kwargs["modes"] = params[1]
+            kwargs["params"] = params[2]
+        else:
+            command = "USERMODE"
+            kwargs["nick"] = params[0]
+            kwargs["modes"] = params[1]
+
     else:
         raise ValueError("Unknown command '{}'".format(command))
 
@@ -381,6 +393,17 @@ def parameters(command: str) -> List[str]:
     elif command in ["RPL_MYINFO", "RPL_BOUNCE"]:
         params.append("info")
         params.append("message")
+    
+    elif command in ["USERMODE"]:
+        add_nickmask(params)
+        params.append("nick")
+        params.append("modes")
+        
+    elif command in ["CHANNELMODE"]:
+        add_nickmask(params)
+        params.append("channel")
+        params.append("modes")
+        params.append("params")
 
     else:
         raise ValueError("Unknown command '{}'".format(command))

--- a/bottom/unpack.py
+++ b/bottom/unpack.py
@@ -302,14 +302,14 @@ def unpack_command(msg: str) -> Tuple[str, Dict[str, Any]]:
 
     elif command in ["MODE"]:
         nickmask(prefix, kwargs)
-        if "#" in params[0]:
+        if params[0][0] in "&#!+":
             command = "CHANNELMODE"
             kwargs["channel"] = params[0]
             kwargs["modes"] = params[1]
             if len(params) > 2:
                 kwargs["params"] = params[2:]
             else:
-                kwargs["params"] = ""
+                kwargs["params"] = []
         else:
             command = "USERMODE"
             kwargs["nick"] = params[0]

--- a/bottom/unpack.py
+++ b/bottom/unpack.py
@@ -396,7 +396,7 @@ def parameters(command: str) -> List[str]:
     elif command in ["RPL_MYINFO", "RPL_BOUNCE"]:
         params.append("info")
         params.append("message")
-    
+
     elif command in ["USERMODE"]:
         add_nickmask(params)
         params.append("nick")

--- a/tests/unit/test_unpack.py
+++ b/tests/unit/test_unpack.py
@@ -182,11 +182,19 @@ def test_topic():
     expected = {"channel": "#ch", "message": "m"}
     validate(command, message, expected)
 
+def test_channelmode_no_params():
+    """ MODE command """
+    command = "CHANNELMODE"
+    expected_kwargs = {"channel": "#ch", "host": "",
+                       "modes": "+m", "params": ""}
+    message = "MODE #ch +m"
+    assert (command, expected_kwargs) == unpack_command(message)
+
 def test_channelmode():
     """ MODE command """
     command = "CHANNELMODE"
     expected_kwargs = {"channel": "#ch", "host": "",
-                        "modes": "+o", "params": "trget"}
+                       "modes": "+o", "params": ['trget']}
     message = "MODE #ch +o trget"
     assert (command, expected_kwargs) == unpack_command(message)
 
@@ -194,7 +202,7 @@ def test_usermode():
     """ MODE command """
     command = "USERMODE"
     expected_kwargs = {"nick": "nck", "host": "",
-                        "modes": "+x"}
+                       "modes": "+x"}
     message = "MODE nck +x"
     assert (command, expected_kwargs) == unpack_command(message)
 

--- a/tests/unit/test_unpack.py
+++ b/tests/unit/test_unpack.py
@@ -182,6 +182,7 @@ def test_topic():
     expected = {"channel": "#ch", "message": "m"}
     validate(command, message, expected)
 
+
 def test_channelmode_no_params():
     """ MODE command """
     command = "CHANNELMODE"
@@ -189,6 +190,7 @@ def test_channelmode_no_params():
                        "modes": "+m", "params": ""}
     message = "MODE #ch +m"
     assert (command, expected_kwargs) == unpack_command(message)
+
 
 def test_channelmode():
     """ MODE command """
@@ -198,6 +200,7 @@ def test_channelmode():
     message = "MODE #ch +o trget"
     assert (command, expected_kwargs) == unpack_command(message)
 
+
 def test_usermode():
     """ MODE command """
     command = "USERMODE"
@@ -205,6 +208,7 @@ def test_usermode():
                        "modes": "+x"}
     message = "MODE nck +x"
     assert (command, expected_kwargs) == unpack_command(message)
+
 
 def test_who_reply():
     """ WHO response """

--- a/tests/unit/test_unpack.py
+++ b/tests/unit/test_unpack.py
@@ -190,6 +190,9 @@ def test_channelmode_no_params():
                        "modes": "+m", "params": ""}
     message = "MODE #ch +m"
     assert (command, expected_kwargs) == unpack_command(message)
+    expected_kwargs['user'] = 'usr'
+    expected_kwargs['nick'] = 'nck'
+    assert set(expected_kwargs) == set(parameters(command))
 
 
 def test_channelmode():
@@ -199,6 +202,9 @@ def test_channelmode():
                        "modes": "+o", "params": ['trget']}
     message = "MODE #ch +o trget"
     assert (command, expected_kwargs) == unpack_command(message)
+    expected_kwargs['user'] = 'usr'
+    expected_kwargs['nick'] = 'nck'
+    assert set(expected_kwargs) == set(parameters(command))
 
 
 def test_usermode():
@@ -208,6 +214,8 @@ def test_usermode():
                        "modes": "+x"}
     message = "MODE nck +x"
     assert (command, expected_kwargs) == unpack_command(message)
+    expected_kwargs['user'] = 'usr'
+    assert set(expected_kwargs) == set(parameters(command))
 
 
 def test_who_reply():

--- a/tests/unit/test_unpack.py
+++ b/tests/unit/test_unpack.py
@@ -182,6 +182,21 @@ def test_topic():
     expected = {"channel": "#ch", "message": "m"}
     validate(command, message, expected)
 
+def test_channelmode():
+    """ MODE command """
+    command = "CHANNELMODE"
+    expected_kwargs = {"channel": "#ch", "host": "",
+                        "modes": "+o", "params": "trget"}
+    message = "MODE #ch +o trget"
+    assert (command, expected_kwargs) == unpack_command(message)
+
+def test_usermode():
+    """ MODE command """
+    command = "USERMODE"
+    expected_kwargs = {"nick": "nck", "host": "",
+                        "modes": "+x"}
+    message = "MODE nck +x"
+    assert (command, expected_kwargs) == unpack_command(message)
 
 def test_who_reply():
     """ WHO response """

--- a/tests/unit/test_unpack.py
+++ b/tests/unit/test_unpack.py
@@ -187,7 +187,7 @@ def test_channelmode_no_params():
     """ MODE command """
     command = "CHANNELMODE"
     expected_kwargs = {"channel": "#ch", "host": "",
-                       "modes": "+m", "params": ""}
+                       "modes": "+m", "params": []}
     message = "MODE #ch +m"
     assert (command, expected_kwargs) == unpack_command(message)
     expected_kwargs['user'] = 'usr'
@@ -195,12 +195,48 @@ def test_channelmode_no_params():
     assert set(expected_kwargs) == set(parameters(command))
 
 
-def test_channelmode():
+def test_channelmode_hash():
     """ MODE command """
     command = "CHANNELMODE"
     expected_kwargs = {"channel": "#ch", "host": "",
-                       "modes": "+o", "params": ['trget']}
-    message = "MODE #ch +o trget"
+                       "modes": "+oo", "params": ['trget', 'trget2']}
+    message = "MODE #ch +oo trget trget2"
+    assert (command, expected_kwargs) == unpack_command(message)
+    expected_kwargs['user'] = 'usr'
+    expected_kwargs['nick'] = 'nck'
+    assert set(expected_kwargs) == set(parameters(command))
+
+
+def test_channelmode_ampersand():
+    """ MODE command """
+    command = "CHANNELMODE"
+    expected_kwargs = {"channel": "&ch", "host": "",
+                       "modes": "+oo", "params": ['trget', 'trget2']}
+    message = "MODE &ch +oo trget trget2"
+    assert (command, expected_kwargs) == unpack_command(message)
+    expected_kwargs['user'] = 'usr'
+    expected_kwargs['nick'] = 'nck'
+    assert set(expected_kwargs) == set(parameters(command))
+
+
+def test_channelmode_bang():
+    """ MODE command """
+    command = "CHANNELMODE"
+    expected_kwargs = {"channel": "!ch", "host": "",
+                       "modes": "+o", "params": ['trget', 'trget2']}
+    message = "MODE !ch +o trget trget2"
+    assert (command, expected_kwargs) == unpack_command(message)
+    expected_kwargs['user'] = 'usr'
+    expected_kwargs['nick'] = 'nck'
+    assert set(expected_kwargs) == set(parameters(command))
+
+
+def test_channelmode_plus():
+    """ MODE command """
+    command = "CHANNELMODE"
+    expected_kwargs = {"channel": "+ch", "host": "",
+                       "modes": "+o", "params": ['trget', 'trget2']}
+    message = "MODE +ch +o trget trget2"
     assert (command, expected_kwargs) == unpack_command(message)
     expected_kwargs['user'] = 'usr'
     expected_kwargs['nick'] = 'nck'


### PR DESCRIPTION
Description
------------
Transforming the MODE returned by the server into USERMODE or CHANNELMODE triggers depending on the type of parameters they are.

`NOTE`: This has been tested on ircu2 and derivatives

```
$ coverage run --branch --source=bottom -m py.test --ignore=tests/integ
======================================================== test session starts ========================================================
platform darwin -- Python 3.6.1, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: /Users/Elijah/sandbox/bottom, inifile:
collected 107 items

tests/unit/test_client.py ....................
tests/unit/test_pack.py .................................................
tests/unit/test_protocol.py .........
tests/unit/test_unpack.py .............................

==================================================== 107 passed in 0.52 seconds =====================================================
```

Test code
----------
```python
    @bot.on("USERMODE")
    def umode(**kwargs):
        logger.debug("USERMODE {}".format(kwargs))

    @bot.on("CHANNELMODE")
    def cmode(**kwargs):
        logger.debug("CHANNELMODE {}".format(kwargs))
```

Sample output:
```
USERMODE {'nick': 'nck', 'user': 'usr', 'host': 'hst', 'modes': '+iwx'}
CHANNELMODE {'nick': 'nck', 'user': 'usr', 'host': 'hst', 'channel': '#ch', 'modes': '+o', 'params': 'bot'}
```