### PR TITLE
correct github link

### DIFF
--- a/docs/_static/bottom.css
+++ b/docs/_static/bottom.css
@@ -1,4 +1,4 @@
-.caption-text, .bloop-gh {
+.caption-text, .bottom-gh {
     color: #2980B9;
 }
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,8 +3,8 @@
     {{ super() }}
     <ul>
         <li class="toctree-l1">
-            <a href="https://www.github.com/numberoverzero/bloop" aria-label="View the source on GitHub">
-                <i class="fa fa-github fa-2x bloop-gh" aria-hidden="true" title="Bloop on GitHub"></i>
+            <a href="https://www.github.com/numberoverzero/bottom" aria-label="View the source on GitHub">
+                <i class="fa fa-github fa-2x bottom-gh" aria-hidden="true" title="Bloop on GitHub"></i>
             </a>
         </li>
     </ul>


### PR DESCRIPTION
the github link in the docs was pointing to the 'bloop' repository
rather than 'bottom'
