### PR TITLE
rewrite removed 'asyncio.coroutine()' implementations for python 3.11 + update bottom.__version__ to 3.0.0

### DIFF
--- a/bottom/__init__.py
+++ b/bottom/__init__.py
@@ -4,4 +4,4 @@ from .protocol import Protocol
 
 
 __all__ = ["Client", "Protocol", "rfc2812_handler"]
-__version__ = "2.2.0"
+__version__ = "3.0.0"

--- a/bottom/client.py
+++ b/bottom/client.py
@@ -137,7 +137,13 @@ class RawClient:
             return functools.partial(self.on, event)
         wrapped = func
         if not asyncio.iscoroutinefunction(wrapped):
-            wrapped = asyncio.coroutine(wrapped)
+            _original_wrapped = wrapped
+
+            @functools.wraps(_original_wrapped)
+            async def wrapper(*args, **kwargs):
+                _original_wrapped(*args, **kwargs)
+
+            wrapped = wrapper
         self._event_handlers[event.upper()].append(wrapped)
         # Always return original
         return func

--- a/docs/user/extension.rst
+++ b/docs/user/extension.rst
@@ -160,7 +160,13 @@ client:
             # Decorator should always return the original function
             wrapped = func
             if not asyncio.iscoroutinefunction(wrapped):
-                wrapped = asyncio.coroutine(wrapped)
+                _original_wrapped = wrapped
+
+                @functools.wraps(_original_wrapped)
+                async def wrapper(*args, **kwargs):
+                    _original_wrapped(*args, **kwargs)
+
+                wrapped = wrapper
 
             compiled = re.compile(pattern)
             self.routes[compiled] = (wrapped, pattern)

--- a/examples/regex.py
+++ b/examples/regex.py
@@ -24,7 +24,13 @@ class Router(object):
         # Decorator should always return the original function
         wrapped = func
         if not asyncio.iscoroutinefunction(wrapped):
-            wrapped = asyncio.coroutine(wrapped)
+            _original_wrapped = wrapped
+
+            @functools.wraps(_original_wrapped)
+            async def wrapper(*args, **kwargs):
+                _original_wrapped(*args, **kwargs)
+
+            wrapped = wrapper
 
         compiled = re.compile(pattern)
         self.routes[compiled] = (wrapped, pattern)


### PR DESCRIPTION
asyncio.coroutine() was depricated in 3.8 and removed in 3.11

This should work as a solid way to resolve this issue